### PR TITLE
Force newline on \n

### DIFF
--- a/test/auto_hyphenating_text_test.dart
+++ b/test/auto_hyphenating_text_test.dart
@@ -460,4 +460,20 @@ void main() async {
 		expect(tester.getSemantics(find.byType(RichText)).label, "How much wood could a woodchuck chuck if a woodchuck could chuck wood?");
 		expect(textNode.label, tester.getSemantics(find.byType(RichText)).label);
 	});
+  testWidgets("Should not remove forced newlines", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: 400,
+            child: AutoHyphenatingText(
+              "This is a veryLongText with a forced\nnewline and two consecutive\n\nnewlines",
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(getText(),
+        r"This is\na very‐\nLongText\nwith a\nforced\nnewline\nand two\nconsecu‐\ntive\n\nnew‐\nlines");
+  });
 }


### PR DESCRIPTION
When input text is formatted with newlines (\n) they will now be preserved in the output.

Sorry, that the formatting is not always correct.
Unfortunately your package is not formatted with `dart format` so it is hard to contribute.