### PR TITLE
Fix hyphenation for selectable text

### DIFF
--- a/lib/src/auto_hyphenating_text.dart
+++ b/lib/src/auto_hyphenating_text.dart
@@ -274,6 +274,7 @@ class AutoHyphenatingText extends StatelessWidget {
           textAlign: textAlign ?? TextAlign.start,
           style: style,
           maxLines: maxLines,
+          cursorWidth: 0,
         );
       } else {
         richText = RichText(


### PR DESCRIPTION
If you use selectable a tiny margin is added for the cursor (the cursor width + 1px). Therefore not the whole width is available for the text. If the text would barely fit in the line this leads to lines where only on single word (which was supposed to fit in the previous line) is written. 

If you set the cursor width to 0, no margin is added, and the hyphenation works fine.