### PR TITLE
Fix word breaking logic for the last word

### DIFF
--- a/lib/src/auto_hyphenating_text.dart
+++ b/lib/src/auto_hyphenating_text.dart
@@ -186,7 +186,8 @@ class AutoHyphenatingText extends StatelessWidget {
           }
         }
 
-        if (currentLineSpaceUsed + wordWidth < constraints.maxWidth - endBuffer) {
+        final isLast = words.length - 1 == i;
+        if (currentLineSpaceUsed + wordWidth < constraints.maxWidth - (isLast ? 0 : endBuffer)) {
           texts.add(TextSpan(text: words[i]));
           currentLineSpaceUsed += wordWidth;
           insertforcedNewLine();


### PR DESCRIPTION
When the last word would actually fit in the available space, then no buffer space for a potential hyphen needs to be reserved.

This bug exhibits itself by a single word getting shoved into a new line, with a nonsensical hyphen added in the end when it would actually _barely_ fit into the available space.

Example:

|without the fix|with the fix|
|-|-|
|<img width="110" height="98" alt="image" src="https://github.com/user-attachments/assets/bd8a21e4-9730-4fb2-91ad-0aa3133becc7" />|<img width="110" height="98" alt="image" src="https://github.com/user-attachments/assets/4352e8b9-942d-42be-86e3-d140b4bf56f3" />|

(available space for the text is marked in red)